### PR TITLE
buffer for src ready

### DIFF
--- a/class-imghaste.php
+++ b/class-imghaste.php
@@ -230,6 +230,10 @@ class Imghaste
 				// Accept CH meta tag
 				$this->loader->add_action('wp_head', $plugin_public, 'imghaste_accept_ch');
 
+				//Replase src and srcset in img tags
+				$this->loader->add_filter('template_redirect', $plugin_public, 'imghaste_imgsrc_buffer_start');
+				$this->loader->add_filter('shutdown', $plugin_public, 'imghaste_imgsrc_buffer_end');
+
 				/*
 				* Implement Slim CSS functionality
 				*/


### PR DESCRIPTION
Two things we need to get in line.
1. I replace all the scrset in picture tags too, not only in img tags. We want that or should I delete it?
2. This functionality means that when the service worker is down we see no images at all! This is a big decision right? 
3. Most importantly we need to see what we do when the service worker is being loaded. First impression and all. Should I load directly from the CDN as I do with the rewrite?